### PR TITLE
Immediate response

### DIFF
--- a/bacalhau/bacalhau.go
+++ b/bacalhau/bacalhau.go
@@ -210,8 +210,11 @@ func StopJob(jobID, reason string, wait bool) (string, error) {
 	return response.EvaluationID, nil
 }
 
-func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostComponents) {
+func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostComponents, string) {
+	
+	var commandType string	
 	// Define the regex pattern to validate the command structure
+
 	pattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+job\s+run\s+https?://\S+$`
 
 	// Compile the regex
@@ -229,8 +232,11 @@ func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostCom
 			components.Text = post
 			components.Url = parts[3] // Assign the 4th part as the URL
 		}
+
+		commandType = "job_file"
+
 	}
 
 	// Check if the post matches the pattern
-	return isCommand, components
+	return isCommand, components, commandType
 }

--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ func dispatchBacalhauJobAndPostReply(session *bsky.Session, notif bsky.Notificat
 	jobFile, jobFileErr := bacalhau.GetLinkedJobFile(jobFileLink)
 	if jobFileErr != nil {
 		fmt.Println("Could not get job file to dispatch job:", jobFileErr)
+
+		jobRetrievalErrTxt := fmt.Sprintf("Sorry! Something went wrong when trying to get your Job file 😔\n\nThe error that came back was %s\n\nPlease check your Job file and try again!", jobFileErr)
+
+		sendReply(session, notif, jobRetrievalErrTxt)
 		return
 	}
 
@@ -214,7 +218,7 @@ func main() {
 		for _, notif := range notifications {
 			// Process only "mention" notifications
 
-			isPostACommand, postComponents := bacalhau.CheckPostIsCommand(notif.Record.Text, bsky.Username)
+			isPostACommand, postComponents, commandType := bacalhau.CheckPostIsCommand(notif.Record.Text, bsky.Username)
 
 			if notif.Reason == "mention" && bsky.ShouldRespond(notif) && !bsky.HasResponded(notif.Uri) && isPostACommand {
 				fmt.Printf("Command detected: %s\n", notif.Record.Text)
@@ -222,11 +226,15 @@ func main() {
 				acknowledgeJobRequest := "We got your job and we're running it now!\n\nYou should get results in a few seconds while we let it run, so hold tight and check your notifications!"
 
 				go sendReply(session, notif, acknowledgeJobRequest)
-				go dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
+
+				if commandType == "job_file" {
+					go dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
+				}
+
 				// dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
 
-				fmt.Printf("Responded to mention: %s\n", notif.Record.Text)
-				bsky.RecordResponse(notif.Uri)    // Record the original mention
+				fmt.Printf("Dipatched jobs and responses to mention: %s\n", notif.Record.Text)
+				bsky.RecordResponse(notif.Uri) // Record the original mention
 
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func main() {
 
 				acknowledgeJobRequest := "We got your job and we're running it now!\n\nYou should get results in a few seconds while we let it run, so hold tight and check your notifications!"
 
-				sendReply(session, notif, acknowledgeJobRequest)
+				go sendReply(session, notif, acknowledgeJobRequest)
 				go dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
 				// dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
 

--- a/main.go
+++ b/main.go
@@ -219,6 +219,9 @@ func main() {
 			if notif.Reason == "mention" && bsky.ShouldRespond(notif) && !bsky.HasResponded(notif.Uri) && isPostACommand {
 				fmt.Printf("Command detected: %s\n", notif.Record.Text)
 
+				acknowledgeJobRequest := "We got your job and we're running it now!\n\nYou should get results in a few seconds while we let it run, so hold tight and check your notifications!"
+
+				sendReply(session, notif, acknowledgeJobRequest)
 				go dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
 				// dispatchBacalhauJobAndPostReply(session, notif, postComponents.Url)
 


### PR DESCRIPTION
Respond to a post when it's first registered so people know that the job has been accepted.

Add in concept of `commandType` to prepare for specific executions that go beyond the typical CLI commands of Bacalhau.