### PR TITLE
Introduce alt-text capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ repopack-output.txt
 security_job.yaml
 Archive.zip
 .DS_Store
+NOTES.md
+auth_flow.sh
+compute_config.yaml

--- a/alt_text_job.yaml
+++ b/alt_text_job.yaml
@@ -1,0 +1,22 @@
+Name: docker job
+Type: batch
+Count: 1
+Tasks:
+  - Name: main
+    Engine:
+      Type: docker
+      Params:
+        Image: seanmtracey/alt-llava:silent
+        EnvironmentVariables:
+          - IMAGE_URL=https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:hw7is7jjkrz2alyls4zqqjiy/bafkreifld7yzgywmtl6ctuafs2vyoq7o3cbldz7mog5dkte7ugskx2p22a@jpeg
+          # - S3_BUCKET=<BUCKET_NAME>
+          # - AWS_ACCESS_KEY_ID=<ACCESS_KEY_ID>
+          # - AWS_SECRET_ACCESS_KEY=<ACCESS_KEY_SECRET>
+          # - S3_BUCKET
+    Network:
+      Type: Full
+    Resources: 
+      CPU: "1"
+      Memory: "50GB"
+      Disk: "10GB"
+      GPU: "1"

--- a/alt_text_job.yaml
+++ b/alt_text_job.yaml
@@ -1,4 +1,4 @@
-Name: docker job
+Name: alt-text job
 Type: batch
 Count: 1
 Tasks:
@@ -9,6 +9,7 @@ Tasks:
         Image: seanmtracey/alt-llava:silent
         EnvironmentVariables:
           - IMAGE_URL=https://cdn.bsky.app/img/feed_thumbnail/plain/did:plc:hw7is7jjkrz2alyls4zqqjiy/bafkreifld7yzgywmtl6ctuafs2vyoq7o3cbldz7mog5dkte7ugskx2p22a@jpeg
+          - SILENT_OUTPUT=true
           # - S3_BUCKET=<BUCKET_NAME>
           # - AWS_ACCESS_KEY_ID=<ACCESS_KEY_ID>
           # - AWS_SECRET_ACCESS_KEY=<ACCESS_KEY_SECRET>

--- a/alt_text_job.yaml
+++ b/alt_text_job.yaml
@@ -1,4 +1,4 @@
-Name: alt-text job
+Name: BBB Alt-Text Job
 Type: batch
 Count: 1
 Tasks:

--- a/bacalhau/bacalhau.go
+++ b/bacalhau/bacalhau.go
@@ -4,12 +4,15 @@ import(
 	"os"
 	"fmt"
 	"bytes"
-	"encoding/json"
+	"io"
+	"time"
 	"regexp"
 	"strings"
+	"errors"
+	"encoding/json"
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
-	"time"
 	
 	"bbb/bsky"
 
@@ -23,6 +26,97 @@ type JobExecutionResult struct {
 }
 
 var BACALHAU_HOST string
+
+func constructOrchestratorURL() (string, error){
+
+	var protocol string
+	var hostName string
+	var portNumber string
+
+	if os.Getenv("USING_SECURE_ORCHESTRATOR") == "true"{
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+
+	if os.Getenv("BACALHAU_HOST") == "" {
+		return "", errors.New("BACALHAU_HOST is not set with environment variables. Cannot construct Orchestrator URL.")
+	} else {
+		hostName = os.Getenv("BACALHAU_HOST")
+	}
+
+	if os.Getenv("BACALHAU_PORT") == ""{
+		fmt.Println("Warning: BACALHAU_PORT is not set with environment variables. Defaulting to 1234")
+		portNumber = "1234"
+	} else {
+		portNumber = os.Getenv("BACALHAU_PORT")
+	}
+
+	constructedURL := fmt.Sprintf(`%s://%s:%s`, protocol, hostName, portNumber)
+
+	return constructedURL, nil
+
+}
+
+func getSignedAuthToken() (string, error) {
+
+	accessToken := os.Getenv("BACALHAU_ACCESS_TOKEN")
+	if accessToken == "" {
+		return "", errors.New("BACALHAU_ACCESS_TOKEN isn't set by environment variables. Cannot generate auth token.")
+	}
+
+	b64Token := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"token":"%s"}`, accessToken)))
+
+	authPayload := map[string]string{
+		"MethodData": b64Token,
+	}
+
+	payloadBytes, err := json.Marshal(authPayload)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode auth payload: %v", err)
+	}
+
+	orchestratorURL, err := constructOrchestratorURL()
+	if err != nil {
+		return "", fmt.Errorf("failed to construct orchestrator URL: %v", err)
+	}
+
+	authEndpoint := fmt.Sprintf("%s/api/v1/auth/shared_secret", orchestratorURL)
+
+	fmt.Println("Authenticating with orchestrator...")
+
+	req, err := http.NewRequest("POST", authEndpoint, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to authenticate with orchestrator: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to authenticate: status %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	var authResponse struct {
+		Authentication struct {
+			Token string `json:"token"`
+		} `json:"Authentication"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&authResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse authentication response: %v", err)
+	}
+
+	return authResponse.Authentication.Token, nil
+
+}
 
 func GetJobFileFromURL(url string) (string, error) {
 
@@ -125,19 +219,93 @@ func GenerateClassificationJob(imageURL string, isHotDogJob bool, className stri
 
 }
 
+func GenerateAltTextJob(imageURL string) (string, error) {
+
+	jobFileTemplate, jtErr := os.ReadFile("./alt_text_job.yaml")
+	if jtErr != nil {
+		return "", fmt.Errorf("an error occurred reading the alt-text job.yaml file: %w", jtErr)
+	}
+
+	// Parse the YAML into a generic map
+	var yamlContent map[string]interface{}
+	if err := yaml.Unmarshal(jobFileTemplate, &yamlContent); err != nil {
+		return "", fmt.Errorf("an error occurred parsing the YAML file: %w", err)
+	}
+
+	// Add or update the IMAGE environment variable manually
+	tasks := yamlContent["Tasks"].([]interface{})
+	firstTask := tasks[0].(map[string]interface{})
+	engine := firstTask["Engine"].(map[string]interface{})
+	params := engine["Params"].(map[string]interface{})
+	envVars := []string{
+		fmt.Sprintf("IMAGE_URL=%s", imageURL),
+		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", os.Getenv("AWS_ACCESS_KEY_ID")),
+		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", os.Getenv("AWS_SECRET_ACCESS_KEY")),
+		fmt.Sprintf("S3_BUCKET=%s", os.Getenv("S3_IMAGE_BUCKET")),
+	}
+
+	params["EnvironmentVariables"] = envVars
+
+	fmt.Println("TASKS:", tasks)
+
+	// Wrap the updated YAML content into the final JSON structure
+	wrappedContent := map[string]interface{}{
+		"Job": yamlContent,
+	}
+
+	// Convert the map to JSON
+	jsonContent, err := json.MarshalIndent(wrappedContent, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("an error occurred converting YAML to JSON: %w", err)
+	}
+
+	// Return the JSON string
+	return string(jsonContent), nil
+
+}
+
 func CreateJob(jobSpec string) JobExecutionResult {
-	url := fmt.Sprintf("http://%s/api/v1/orchestrator/jobs", BACALHAU_HOST)
-	fmt.Println("Sending job to:", url)
+
+	var token string
+	var tokenErr error
+
+	orchestratorURL, orchErr := constructOrchestratorURL()
+
+	if orchErr != nil {
+		fmt.Println("Could not create Job:", orchErr.Error())
+		return JobExecutionResult{}
+	}
+
+	if os.Getenv("USING_SECURE_ORCHESTRATOR") == "true" {
+
+		token, tokenErr = getSignedAuthToken()
+
+		if tokenErr != nil {
+
+			fmt.Println("Could not create Job:", tokenErr.Error())
+			return JobExecutionResult{}
+
+		}
+
+	}
+
+	createJobURL := fmt.Sprintf("%s/api/v1/orchestrator/jobs", orchestratorURL)
+	fmt.Println("Sending job to:", createJobURL)
 
 	// Convert the job specification string to a JSON byte slice
 	jsonData := []byte(jobSpec)
 
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("PUT", createJobURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		fmt.Printf("Error creating HTTP request: %v\n", err)
 		return JobExecutionResult{}
 	}
 	req.Header.Set("Content-Type", "application/json")
+	
+	if os.Getenv("USING_SECURE_ORCHESTRATOR") == "true" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token) )
+	}
+
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -171,13 +339,17 @@ func CreateJob(jobSpec string) JobExecutionResult {
 	fmt.Println("Waiting for 30 seconds before querying executions...")
 	time.Sleep(30 * time.Second)
 
-	executionsURL := fmt.Sprintf("http://%s/api/v1/orchestrator/jobs/%s/executions", BACALHAU_HOST, response.JobID)
+	executionsURL := fmt.Sprintf("%s/api/v1/orchestrator/jobs/%s/executions", orchestratorURL, response.JobID)
 	fmt.Println("executionsURL:", executionsURL)
 
 	req, err = http.NewRequest("GET", executionsURL, nil)
 	if err != nil {
 		fmt.Printf("Error creating request for executions: %v\n", err)
 		return JobExecutionResult{}
+	}
+
+	if os.Getenv("USING_SECURE_ORCHESTRATOR") == "true" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token) )
 	}
 
 	resp, err = client.Do(req)
@@ -292,18 +464,21 @@ func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostCom
 	classifyJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+classify`
 	hotDogDetectionJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+hotdog?`
 	arbitraryClassPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+(\w+)\?$`
+	altTextJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+alt-text`
 
 	// Compile the regex
 	jobRunRegex := regexp.MustCompile(jobRunPattern)
 	classifyJobRegex := regexp.MustCompile(classifyJobPattern)
 	hotDogJobRegex := regexp.MustCompile(hotDogDetectionJobPattern)
 	arbitraryClassRegex := regexp.MustCompile(arbitraryClassPattern)
+	altTextJobRegex := regexp.MustCompile(altTextJobPattern)
 
 	// Check if the post matches any command pattern
 	isJobRunCommand := jobRunRegex.MatchString(post)
 	isClassifyJobCommand := classifyJobRegex.MatchString(post)
 	isHotDogJobCommand := hotDogJobRegex.MatchString(post)
 	isArbitraryClassCommand := arbitraryClassRegex.MatchString(post)
+	isAltTextCommand := altTextJobRegex.MatchString(post)
 
 	components := bsky.PostComponents{}
 	parts := strings.Fields(post)
@@ -332,8 +507,12 @@ func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostCom
 		}
 	}
 
+	if isAltTextCommand {
+		commandType = "altText"
+	}
+
 	// Check if the post matches any of the patterns
-	return isJobRunCommand || isClassifyJobCommand || isHotDogJobCommand || isArbitraryClassCommand, components, commandType, className
+	return isJobRunCommand || isClassifyJobCommand || isHotDogJobCommand || isArbitraryClassCommand || isAltTextCommand, components, commandType, className
 
 }
 

--- a/bacalhau/bacalhau.go
+++ b/bacalhau/bacalhau.go
@@ -264,7 +264,7 @@ func GenerateAltTextJob(imageURL string) (string, error) {
 
 }
 
-func CreateJob(jobSpec string) JobExecutionResult {
+func CreateJob(jobSpec string, timeToWaitForResults int) JobExecutionResult {
 
 	var token string
 	var tokenErr error
@@ -335,9 +335,10 @@ func CreateJob(jobSpec string) JobExecutionResult {
 
 	fmt.Printf("Job created successfully with ID: %s\n", response.JobID)
 
-	// Wait for 20 seconds
-	fmt.Println("Waiting for 30 seconds before querying executions...")
-	time.Sleep(30 * time.Second)
+	// Wait for a given period before retrieving results...
+	fmt.Println(fmt.Sprintf(`Waiting for %d seconds before querying executions for Job "%s"...`, timeToWaitForResults, response.JobID))
+	waitTime := time.Duration(timeToWaitForResults) * time.Second
+	time.Sleep(waitTime)
 
 	executionsURL := fmt.Sprintf("%s/api/v1/orchestrator/jobs/%s/executions", orchestratorURL, response.JobID)
 	fmt.Println("executionsURL:", executionsURL)
@@ -382,13 +383,6 @@ func CreateJob(jobSpec string) JobExecutionResult {
 		fmt.Printf("No executions found for JobID: %s\n", response.JobID)
 		return JobExecutionResult{}
 	}
-
-	// firstExecution := executionsResponse.Items[0]
-	// return JobExecutionResult{
-	// 	JobID:       response.JobID,
-	// 	ExecutionID: firstExecution.ID,
-	// 	Stdout:      firstExecution.RunOutput.Stdout,
-	// }
 
 	chosenJobToReturn := JobExecutionResult{
 		JobID: response.JobID,

--- a/bacalhau/bacalhau.go
+++ b/bacalhau/bacalhau.go
@@ -391,7 +391,6 @@ func CreateJob(jobSpec string, timeToWaitForResults int) JobExecutionResult {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token) )
 	}
 
-
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/bacalhau/bacalhau.go
+++ b/bacalhau/bacalhau.go
@@ -464,21 +464,23 @@ func CheckPostIsCommand(post string, accountUsername string) (bool, bsky.PostCom
 	classifyJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+classify`
 	hotDogDetectionJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+hotdog?`
 	arbitraryClassPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+(\w+)\?$`
-	altTextJobPattern := `^@` + regexp.QuoteMeta(accountUsername) + `\s+alt-text`
 
 	// Compile the regex
 	jobRunRegex := regexp.MustCompile(jobRunPattern)
 	classifyJobRegex := regexp.MustCompile(classifyJobPattern)
 	hotDogJobRegex := regexp.MustCompile(hotDogDetectionJobPattern)
 	arbitraryClassRegex := regexp.MustCompile(arbitraryClassPattern)
-	altTextJobRegex := regexp.MustCompile(altTextJobPattern)
 
 	// Check if the post matches any command pattern
 	isJobRunCommand := jobRunRegex.MatchString(post)
 	isClassifyJobCommand := classifyJobRegex.MatchString(post)
 	isHotDogJobCommand := hotDogJobRegex.MatchString(post)
 	isArbitraryClassCommand := arbitraryClassRegex.MatchString(post)
-	isAltTextCommand := altTextJobRegex.MatchString(post)
+	isAltTextCommand := false
+
+	if strings.Contains(accountUsername, "alt-text.bots.bacalhau.org") {
+		isAltTextCommand = true
+	}
 
 	components := bsky.PostComponents{}
 	parts := strings.Fields(post)

--- a/bsky/bsky.go
+++ b/bsky/bsky.go
@@ -41,8 +41,15 @@ type Record struct {
 	Text      string  `json:"text,omitempty"`
 	CreatedAt string  `json:"createdAt"`
 	Facets    []Facet `json:"facets,omitempty"`
-	Embed     *Embed  `json:"embed,omitempty"` // Change from []Embed to *Embed
+	Embed     *Embed  `json:"embed,omitempty"`
+	Reply     *Reply  `json:"reply,omitempty"` // Add this line
 }
+
+type Reply struct {
+	Root   map[string]string `json:"root"`
+	Parent map[string]string `json:"parent"`
+}
+
 
 type Facet struct {
 	Type     string    `json:"$type"`
@@ -366,6 +373,58 @@ func ReplyToMention(jwt string, notif Notification, text string, userDid string)
 
 	return "", fmt.Errorf("response URI not found")
 }
+
+func GetRepliedToPost(jwt string, notif Notification) (*Notification, error) {
+	// Ensure the notification has a reply reference
+	if notif.Record.Reply == nil {
+		return nil, fmt.Errorf("notification is not a reply")
+	}
+
+	// Construct the URL to fetch the parent post
+	parentUri := notif.Record.Reply.Parent["uri"]
+	url := fmt.Sprintf("%s/app.bsky.feed.getPostThread?uri=%s", blueskyAPIBase, parentUri)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to fetch post, status code: %d, response: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Parse the response
+	var response struct {
+		Thread struct {
+			Post Notification `json:"post"`
+		} `json:"thread"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	parentPost := &response.Thread.Post
+
+	// Extract image URL if present
+	if parentPost.Record.Embed != nil && parentPost.Record.Embed.Type == "app.bsky.embed.images" && len(parentPost.Record.Embed.Images) > 0 {
+		imageRef := parentPost.Record.Embed.Images[0].Image.Ref["$link"]
+		parentPost.ImageURL = fmt.Sprintf("https://cdn.bsky.app/img/feed_thumbnail/plain/%s/%s@jpeg", parentPost.Author.Did, imageRef)
+	}
+
+	return parentPost, nil
+}
+
 
 
 func ProcessNotifications(notifications []Notification) []Notification {

--- a/bsky/bsky.go
+++ b/bsky/bsky.go
@@ -91,8 +91,6 @@ type PostComponents struct {
 	Url string
 }
 
-var Username string
-var Password string
 var blueskyAPIBase = "https://bsky.social/xrpc"
 var StartTime time.Time
 var RespondedFile = "responded_to.txt"

--- a/classify_job.yaml
+++ b/classify_job.yaml
@@ -1,4 +1,4 @@
-Name: docker job
+Name: classify job
 Type: batch
 Count: 1
 Tasks:

--- a/classify_job.yaml
+++ b/classify_job.yaml
@@ -1,4 +1,4 @@
-Name: classify job
+Name: BBB Classify Job
 Type: batch
 Count: 1
 Tasks:

--- a/main.go
+++ b/main.go
@@ -306,7 +306,9 @@ func startHTTPServer() {
 	fmt.Printf("Starting HTTP server on port %s\n", port)
 	go func() {
 		if err := http.ListenAndServe(port, nil); err != nil {
-			fmt.Printf("HTTP server failed: %v\n", err)
+			fmt.Printf("HTTP server failed: %s\n", err.Error())
+			fmt.Println("Unexpected condition in application. Exiting.")
+			os.Exit(1)
 		}
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -116,15 +116,27 @@ func dispatchAltTextJobAndPostReply(session *bsky.Session, notif bsky.Notificati
 
 	if pPostErr != nil {
 		fmt.Printf("Parent Post err: %s\n", pPostErr.Error())
+		errorResponseTxt := "Sorry, we weren't able to get that post to generate alt-text. Please try again later!"
+		sendReply(session, notif, errorResponseTxt)
+		return
 	}
 
 	fmt.Printf("Parent Post: %+v\n", parentPost)
 	fmt.Printf("Parent Post Image: %s\n", parentPost.ImageURL)
 
+	if parentPost.ImageURL == "" {
+		errorResponseTxt := "Sorry, we weren't able to to find an image in that post to generate alt-text. Please try again later!"
+		sendReply(session, notif, errorResponseTxt)
+		return
+	}
+
 	job, jErr := bacalhau.GenerateAltTextJob(parentPost.ImageURL)
 
 	if jErr != nil {
 		fmt.Printf("Could not generate alt-text Job file: %s", jErr.Error())
+		errorResponseTxt := "Sorry, something went wrong with the Bot! Please try again later!"
+		sendReply(session, notif, errorResponseTxt)
+		return
 	}
 
 	fmt.Println("Job file JSON:", job)


### PR DESCRIPTION
With this PR, the Bacalhau Bluesky Bot can now utilise multiple accounts to respond to specific functionalities. Specifically, requests to @alt-txt.bots.bacalhau.org will now dispatch jobs to generate alt-text using LLaVa for Bluesky posts, and respond to the querier with the output.

Additionally, error handling has been slightly enhanced, and the use of an Expanso Cloud Managed Orchestrator (or Bacalhau orchestrators using TLS) has been implemented.